### PR TITLE
Replace `Dark mode (experimental)` wordings on Settings page #54

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -38,8 +38,7 @@
                     name="app-dark-mode"
                     id="app-dark-mode"
                   />
-                  Dark mode
-                  <small>&lpar;experimental&rpar;</small>
+                  Enable dark mode
                 </label>
               </div>
               <!-- /.mb-1 -->


### PR DESCRIPTION
- Labelled "Enable dark mode"
![Screenshot from 2020-10-08 00-30-24](https://user-images.githubusercontent.com/7559080/95360069-79508400-08fd-11eb-8f04-73faa8dcae25.png)
